### PR TITLE
Support building the extension on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,2 +1,5 @@
-ARG_ENABLE('php-md4c', 'test support', 'no');
+ARG_ENABLE('md4c', 'Enable the md4c extension', 'no');
 
+if (PHP_MD4C != 'no') {
+    EXTENSION('md4c', 'md4c.c');
+}


### PR DESCRIPTION
We change the name of the configure option to the more customary `md4c` (without the `php-` prefix), what also matches config.m4.  We stick, however, with `enable` (contrary to config.m4) since the md4c dependency is now bundled, so specifying a path wouldn't make sense. We also use a descriptive help text.

But most importantly, we actually register the extension to be built, if enabled by the user.