### PR TITLE
Adapt enabling and help text for *nix configuration

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,8 +1,7 @@
 dnl config.m4 for php-md4c extension
 
-PHP_ARG_WITH(md4c, [whether to enable MD4C support],
-[  --with-md4c[[=DIR]]       Enable MD4C support.
-                          DIR is the path to MD4C install prefix])
+PHP_ARG_ENABLE(md4c, [whether to enable MD4C support],
+[  --enable-md4c           Enable MD4C support.])
 
 if test "$PHP_MD4C" != "no"; then
 	PHP_SUBST(MD4C_SHARED_LIBADD)


### PR DESCRIPTION
Since support for an external md4c library has been removed[1], the help text needs to be adjusted.  We also switch to `--enable-md4c` which matches the Windows configuration, and is more typical for extensions not relying on external libraries.

[1] <https://github.com/eklausme/php-md4c/commit/68b8d5b9304eab42c12077f4cddd9e94972f2876>

---

Note that the most important is fixing the help text; feel free to stick with `--with-md4c`. There is not much consistency regarding the use of `with` or `enable` anyway, and PHP might switch to [use these interchangeably anyway](https://github.com/php/php-tasks/issues/2).