### PR TITLE
Implement flag constants

### DIFF
--- a/md4c.c
+++ b/md4c.c
@@ -9913,6 +9913,9 @@ PHP_MINIT_FUNCTION(md4c) {	// module initialization
 	//REGISTER_INI_ENTRIES();
 	//php_printf("In PHP_MINIT_FUNCTION(md4c): module initialization\n");
 
+	REGISTER_LONG_CONSTANT("MD4C_DIALECT_GITHUB", MD_DIALECT_GITHUB, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("MD4C_FLAG_NOINDENTEDCODEBLOCKS", MD_FLAG_NOINDENTEDCODEBLOCKS, CONST_PERSISTENT);
+
 	return SUCCESS;
 }
 /* }}} */
@@ -9981,7 +9984,7 @@ zend_module_entry md4c_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"md4c",				// Extension name
 	php_md4c_functions,		// zend_function_entry
-	NULL,	//PHP_MINIT(md4c),		// PHP_MINIT - Module initialization
+	PHP_MINIT(md4c),		// PHP_MINIT - Module initialization
 	PHP_MSHUTDOWN(md4c),		// PHP_MSHUTDOWN - Module shutdown
 	NULL,				// PHP_RINIT - Request initialization
 	NULL,				// PHP_RSHUTDOWN - Request shutdown

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Indented code blocks
+--EXTENSIONS--
+md4c
+--FILE--
+<?php
+$md = <<<'EOS'
+a simple
+
+    indented code block
+EOS;
+echo md4c_toHtml($md);
+echo "---\n";
+echo md4c_toHtml($md, MD4C_DIALECT_GITHUB);
+?>
+--EXPECT--
+<p>a simple</p>
+<p>indented code block</p>
+---
+<p>a simple</p>
+<pre><code>indented code block
+</code></pre>


### PR DESCRIPTION
The `$flags` argument of `md4c_toHtml()` accepts an int.  However, when reading code, magic numbers are hard to understand, and the underlying values may change with new md4c releases.  As such it seems sensible to actually define respective PHP constants.

We also add a test to check that the `$flags` arguments generally works, and to also check that the `MD4C_DIALECT_GITHUB` constant does not include `MD4C_FLAG_NOINDENTEDCODEBLOCKS` (which is contained in the default value).

---

Note that it probably makes sense to define all FLAG and DIALOG constants

https://github.com/eklausme/php-md4c/blob/9ee81e258a2bb2b2ab9623a0918ef9204410b289/md4c.c#L373-L407

However, also note that while this "manual" definition was what we had prior to PHP 8.0.0, you can now write [stub files](https://php.github.io/php-src/miscellaneous/stubs.html) and let gen_stub.php automatically generate the respective C code. It gets a bit fiddly if you also want to support PHP 7, but it is [possible](https://php.github.io/php-src/miscellaneous/stubs.html).