### PR TITLE
add option to build with system libmd4c

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,9 +1,23 @@
 dnl config.m4 for php-md4c extension
 
 PHP_ARG_ENABLE(md4c, [whether to enable MD4C support],
-[  --enable-md4c           Enable MD4C support.])
+	[AS_HELP_STRING([--enable-md4c], [Enable MD4C support])], [yes], [yes])
+
+PHP_ARG_ENABLE(system-libmd4c, [whether to enable system libmd4c library],
+	[AS_HELP_STRING([--enable-system-md4c], [Enable system libmd4c])], [no], [no])
 
 if test "$PHP_MD4C" != "no"; then
+	if test "$PHP_SYSTEM_LIBMD4C" = "yes"; then
+		AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+
+		PKG_CHECK_MODULES([LIBMD4C_HTML], [md4c-html])
+		PHP_EVAL_INCLINE($LIBMD4C_HTML_CFLAGS)
+		PHP_EVAL_LIBLINE($LIBMD4C_HTML_LIBS, MD4C_SHARED_LIBADD)
+		AC_DEFINE([HAVE_LIBMD4C], 1, [With system libmd4c library])
+
+		LIBMD4C_VERSION=`$PKG_CONFIG md4c-html --modversion`
+		AC_DEFINE_UNQUOTED([PHP_LIBMD4C_VERSION], ["$LIBMD4C_VERSION"], [With system libmd4c library])
+	fi
 	PHP_SUBST(MD4C_SHARED_LIBADD)
 	AC_DEFINE(HAVE_MD4C, 1, [ ])
 	PHP_NEW_EXTENSION(md4c, md4c.c, $ext_shared)

--- a/md4c.c
+++ b/md4c.c
@@ -17,8 +17,11 @@
 #include <php.h>
 #include <ext/standard/info.h>
 
+#ifdef HAVE_LIBMD4C
 
+#include <md4c-html.h>
 
+#else
 // Begin amalgamate
 
 // entity.h
@@ -9805,6 +9808,7 @@ md_html(const MD_CHAR* input, MD_SIZE input_size,
 
 
 // End amalgamate
+#endif
 
 
 
@@ -9951,7 +9955,11 @@ PHP_MINFO_FUNCTION(md4c) {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "MD4C", "enabled");
 	php_info_print_table_row(2, "PHP-MD4C version", "1.1");
-	php_info_print_table_row(2, "MD4C version", "0.5.2");
+#ifdef HAVE_LIBMD4C
+	php_info_print_table_row(2, "MD4C system library version", PHP_LIBMD4C_VERSION);
+#else
+	php_info_print_table_row(2, "MD4C bundled library version", "0.5.2");
+#endif
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Best practice is to used shared system libraries, and avoid bundling their sources

At least, libmd4c is available in [Fedora](https://src.fedoraproject.org/rpms/md4c) and [Debian](https://packages.debian.org/search?keywords=md4c&searchon=names&suite=all&section=all) 

Using this patch

```
=====================================================================
TIME START 2024-12-02 08:28:37
=====================================================================
PASS Basic conversion [tests/001.phpt] 
PASS Indented code blocks [tests/002.phpt] 
=====================================================================
TIME END 2024-12-02 08:28:37
=====================================================================
```

Tested with version 0.4.8 and 0.5.2