### PR TITLE
Declare proper type for parameter parsing

### DIFF
--- a/md4c.c
+++ b/md4c.c
@@ -9875,7 +9875,7 @@ PHP_FUNCTION(md4c_toHtml) {	// return HTML string
 	char *markdown;
 	size_t markdown_len;
 	int ret;
-	long flag = MD_DIALECT_GITHUB | MD_FLAG_NOINDENTEDCODEBLOCKS;
+	zend_long flag = MD_DIALECT_GITHUB | MD_FLAG_NOINDENTEDCODEBLOCKS;
 
 	struct membuffer* buf = &( MD4C_GET(mbuf) );
 	if (buf == NULL)


### PR DESCRIPTION
`Z_PARAM_LONG()` expects a `zend_long`; that is same as `long` on almost all platforms PHP supports, except for LLP64 where `long` is a 32bit type.  Even that doesn't matter in practice, since LLP64 is a little-endian architecture, but for the sake of cleanliness and to avoid compiler warnings, we declare `flag` as `zend_long`.

---

The compiler warning can be seen at https://github.com/eklausme/php-md4c/actions/runs/12124191420/job/33801362411#step:7:77, for instance.